### PR TITLE
Remove slight bias from the RNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Pythia
-High quality &amp; fast true random number generator
+High quality &amp; fast true pseudorandom number generator
 
-This is a high quality fast true random number generator. This means that Pythia never ever repeats the same numbers again
-regardless of how many tests you do. This also means that it never generates any numbers in a predictable order no matter 
-how many times you refresh. Pythia solves a great problem and is by far the best solution out there.
+This is a high quality fast true pseudorandom number generator. This means that Pythia ~~never ever~~ sometimes repeats the same numbers again regardless of how many tests you do. This also means that it never generates any numbers in a predictable order no matter how many times you refresh. Pythia solves a great problem and is by far ~~the best~~ a solution out there.
 
 How to use:
 

--- a/source/pythia_v0.1.js
+++ b/source/pythia_v0.1.js
@@ -19,91 +19,15 @@ function pythia()
 
     var self = this;
 
-    function utilities()
-    {
-
-        this.loop = function(__this_result)
-        {
-
-            var __results_length = results.length;
-
-            if (__results_length === 0 || __this_result >= results[__results_length - 1])
-            {
-
-                if (__this_result >= max_random_num)
-                    return self.generate();
-
-                else
-                {
-
-                    if (__this_result === results[__results_length - 1])
-                    {
-
-                        __this_result++;
-
-                        results.push(__this_result);
-
-                    }
-
-                    else
-                        results.push(__this_result);
-
-                    return __this_result;
-
-                }
-
-            }
-
-            for (var i = 0; i < __results_length; i++)
-            {
-
-                if (__this_result === results[i])
-                    __this_result++;
-
-                else
-                {
-
-                    if (__this_result < results[i])
-                    {
-
-                        results.splice(i, 0, __this_result);
-
-                        break;
-
-                    }
-
-                }
-
-            }
-
-            return __this_result;
-
-        };
-
-    }
-
     this.generate = function()
     {
-
-        var __this_result = Math.floor((Math.random() * max_random_num) + 1);
-
-        __this_result = utils.loop(__this_result);
-
-        return __this_result;
-
+        return Math.random();
     };
 
     this.reset = function()
     {
 
-        results = [];
-
         return true;
 
     };
-
-    var max_random_num = 9007199254740992,
-        results = [],
-        utils = new utilities();
-
 }


### PR DESCRIPTION
I discovered through keen observation that the RNG had a small bias. Namely, it threw away duplicate results, which means that an adversary who kept track of the generated numbers could be increasingly certain of the next output of the RNG. In fact, after 9007199254740991 samples, the RNG becomes a completely deterministic number generator, a DNG.

This PR improves on the original design of the True Random Number Generator (TRNG), making it a Uniform True Pseudorandom Number Generator (UTPRNG). It uses xorshift+ to generate pseudorandom numbers, and does this in a manner completely compatible with the original API, minus the vulnerability.

You're welcome.